### PR TITLE
Remove HTTPS complexity from development environment

### DIFF
--- a/docs/feature-notes/home-page.md
+++ b/docs/feature-notes/home-page.md
@@ -83,10 +83,7 @@ Built using the project's lightweight MVC framework with server-side rendering:
 6. **Error Handling**: User-friendly error messages for validation failures and duplicate IDs
 
 ### Development Environment Setup
-**HTTPS Configuration**: Implemented proper SSL certificates for development using OpenSSL with Subject Alternative Names (SAN):
-- Certificate path: `/workspace/image-vault/.certs/`
-- SAN entries include: localhost, claude-code, *.claude-code, 127.0.0.1, 0.0.0.0
-- Eliminates certificate bypass needs while maintaining security
+**HTTP Configuration**: Simplified development setup using HTTP only for local development, eliminating certificate management complexity.
 
 **Content Security Policy**: Configured helmet middleware to allow inline scripts and event handlers required for the MVC framework's client-side controller functionality.
 
@@ -95,11 +92,10 @@ Built using the project's lightweight MVC framework with server-side rendering:
 - `src/ui/pages/home/view.ts` - HTML template rendering with embedded styles
 - `src/ui/pages/home/controller.ts` - Client-side interaction handling  
 - `src/ui/mvc.ts` - Enhanced framework with inline CSS/JS support
-- `src/api/server.ts` - Added home route and HTTPS server configuration
+- `src/api/server.ts` - Added home route and HTTP server configuration
 - `tests/ui/ui-model/image-vault-app.ts` - Application-specific test utilities
 - `tests/ui/ui-model/pages/home-page-driver.ts` - Page object for home page interactions
 - `tests/ui/ui-model/element.ts` - Added missing `isDisabled()` method
-- `.certs/openssl.conf` - SSL certificate configuration with proper SAN entries
 
 ### API Integration
 - **GET /**: Renders home page with collection data via MVC framework
@@ -109,7 +105,7 @@ Built using the project's lightweight MVC framework with server-side rendering:
 
 ### Production Readiness
 - ✅ Complete test coverage with 9/9 acceptance tests passing
-- ✅ Proper HTTPS configuration for development and production
+- ✅ Simplified HTTP configuration for development (HTTPS can be added for production)
 - ✅ Client and server-side validation
 - ✅ Comprehensive error handling and user feedback
 - ✅ Responsive design with embedded CSS

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/uuid": "^10.0.0",
     "eslint": "^9.33.0",
     "globals": "^16.3.0",
-    "https": "*",
     "nodemon": "^3.1.10",
     "tsx": "^4.20.3",
     "typescript": "^5.9.2",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import helmet from 'helmet';
-import https from 'https';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { Collection } from '../domain/collection';
@@ -296,28 +295,9 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-// Start HTTPS server for development
-async function startServer() {
-  try {
-    const certPath = path.join(__dirname, '../../.certs/cert.pem');
-    const keyPath = path.join(__dirname, '../../.certs/key.pem');
-    
-    const cert = await fs.readFile(certPath, 'utf8');
-    const key = await fs.readFile(keyPath, 'utf8');
-    
-    const httpsServer = https.createServer({ cert, key }, app);
-    
-    httpsServer.listen(port, '0.0.0.0', () => {
-      console.log(`Image Vault API server running on https://0.0.0.0:${port}`);
-    });
-  } catch (error) {
-    console.error('Failed to start HTTPS server, falling back to HTTP:', error);
-    app.listen(port, '0.0.0.0', () => {
-      console.log(`Image Vault API server running on http://0.0.0.0:${port}`);
-    });
-  }
-}
-
-startServer();
+// Start HTTP server
+app.listen(port, () => {
+  console.log(`Image Vault API server running on http://localhost:${port}`);
+});
 
 export { app };

--- a/tests/api/specs/collections-api-endpoint.spec.ts
+++ b/tests/api/specs/collections-api-endpoint.spec.ts
@@ -2,14 +2,14 @@ import { test, expect } from '@playwright/test';
 import { CollectionsAPI } from '../utils/collections-api-model';
 import { CollectionsDirectoryFixtures } from '../utils/collections-directory-fixtures';
 import { Fixtures } from '../../utils/fixtures/base-fixtures';
+import { TEST_CONFIG } from '../../utils/test-config';
 
 test.describe('Collections API Endpoint', () => {
   let api: CollectionsAPI;
 
-  // Setup API client - assuming server runs on localhost:3000
-  // TODO: Make this configurable via environment variable
+  // Setup API client using shared test configuration
   test.beforeAll(() => {
-    api = new CollectionsAPI('https://localhost:3000');
+    api = new CollectionsAPI(TEST_CONFIG.API_BASE_URL);
   });
 
   // Cleanup fixtures after each test

--- a/tests/api/specs/collections-images-endpoint.spec.ts
+++ b/tests/api/specs/collections-images-endpoint.spec.ts
@@ -3,14 +3,14 @@ import { CollectionsAPI } from '../utils/collections-api-model';
 import { CollectionsImagesAPIUtils } from '../utils/collections-images-api-utils';
 import { CollectionFixtures } from '../../utils/fixtures/collection-fixtures';
 import { Fixtures } from '../../utils/fixtures/base-fixtures';
+import { TEST_CONFIG } from '../../utils/test-config';
 
 test.describe('Collections Images API Endpoint', () => {
   let api: CollectionsAPI;
 
-  // Setup API client - assuming server runs on localhost:3000
-  // TODO: Make this configurable via environment variable
+  // Setup API client using shared test configuration
   test.beforeAll(() => {
-    api = new CollectionsAPI('https://localhost:3000');
+    api = new CollectionsAPI(TEST_CONFIG.API_BASE_URL);
   });
 
   // Setup private directory before each test

--- a/tests/api/specs/images-serving-endpoint.spec.ts
+++ b/tests/api/specs/images-serving-endpoint.spec.ts
@@ -3,12 +3,13 @@ import { CollectionsAPI } from '../utils/collections-api-model';
 import { ImageServingFixtures } from '../utils/image-serving-fixtures';
 import { BinaryResponseUtils } from '../utils/binary-response-utils';
 import { Fixtures } from '../../utils/fixtures/base-fixtures';
+import { TEST_CONFIG } from '../../utils/test-config';
 
 test.describe('Image Serving API Endpoints', () => {
   let api: CollectionsAPI;
 
   test.beforeAll(() => {
-    api = new CollectionsAPI('https://localhost:3000');
+    api = new CollectionsAPI(TEST_CONFIG.API_BASE_URL);
   });
 
   test.afterEach(async () => {

--- a/tests/api/utils/api-model.ts
+++ b/tests/api/utils/api-model.ts
@@ -73,10 +73,6 @@ export class APIModel {
         body: options.body ? JSON.stringify(options.body) : undefined,
       };
 
-      // For Node.js environments with self-signed certificates, bypass certificate validation
-      if (typeof process !== 'undefined' && process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0') {
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-      }
 
       console.log(`Making a ${method} request to "${url.toString()}"`);
 

--- a/tests/ui/playwright.config.ts
+++ b/tests/ui/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import { TEST_CONFIG } from '../utils/test-config';
 
 export default defineConfig({
   testDir: './specs',
@@ -11,11 +12,10 @@ export default defineConfig({
     ['list']
   ],
   use: {
-    baseURL: 'https://claude-code:3000',
+    baseURL: TEST_CONFIG.UI_BASE_URL,
     // trace: 'on-first-retry',
     // screenshot: 'only-on-failure',
     headless: true,
-    ignoreHTTPSErrors: true, // Ignore self-signed certificate errors
     connectOptions: {
       wsEndpoint: 'ws://playwright-server:8080',  // Connect to the remote playwright server
     },

--- a/tests/ui/ui-model/pages/home-page-driver.ts
+++ b/tests/ui/ui-model/pages/home-page-driver.ts
@@ -2,6 +2,7 @@ import { expect } from 'playwright/test';
 import { PageObject } from '../page';
 import { Element } from '../element';
 import { ConfirmationDialogComponent } from '../components/confirmation-dialog-component';
+import { TEST_CONFIG } from '../../../utils/test-config';
 
 export class HomePageDriver extends PageObject {
   protected url = '/';
@@ -97,7 +98,7 @@ export class HomePageDriver extends PageObject {
     const currentUrl = this.page.url();
     expect(currentUrl, { 
       message: `Current URL is "${currentUrl}" instead of home page after navigation` 
-    }).toBe(`https://claude-code:3000${this.url}`);
+    }).toBe(`${TEST_CONFIG.UI_BASE_URL}${this.url}`);
     console.log('✓ User is on home page');
   }
 

--- a/tests/ui/utils/home-page-fixtures.ts
+++ b/tests/ui/utils/home-page-fixtures.ts
@@ -1,6 +1,7 @@
 import { CollectionsAPI } from '../../api/utils/collections-api-model';
 import { CollectionsDirectoryFixtures } from '../../api/utils/collections-directory-fixtures';
 import { Fixtures } from '../../utils/fixtures/base-fixtures';
+import { TEST_CONFIG } from '../../utils/test-config';
 
 interface CollectionListItem {
   id: string;
@@ -11,7 +12,7 @@ interface CollectionListItem {
  * Uses the existing API testing infrastructure to set up collections
  */
 export class HomePageFixtures extends Fixtures<CollectionListItem[]> {
-  private static collectionsAPI = new CollectionsAPI('https://claude-code:3000');
+  private static collectionsAPI = new CollectionsAPI(TEST_CONFIG.UI_BASE_URL);
 
   /**
    * Creates an empty collections state for testing empty state UI

--- a/tests/utils/test-config.ts
+++ b/tests/utils/test-config.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared test configuration for consistent URLs across test suites
+ */
+
+export const TEST_CONFIG = {
+  // Base URLs for different environments
+  API_BASE_URL: process.env.API_BASE_URL || 'http://localhost:3000',
+  UI_BASE_URL: process.env.UI_BASE_URL || 'http://claude-code:3000',
+} as const;


### PR DESCRIPTION
## Summary
- Simplified server configuration to use HTTP only for local development
- Removed certificate files (.certs/) and SSL dependencies
- Converted all test URLs from HTTPS to HTTP
- Added shared test configuration with centralized base URL constants
- Removed TLS bypass code from API test utilities

## Benefits
- Eliminates certificate management complexity
- Reduces development friction (no browser warnings, cert trust issues)
- Simplifies testing infrastructure
- Maintains full functionality while reducing setup overhead

## Test Results
- ✅ Domain tests: 20/20 passing
- ✅ API tests: 24/26 passing (2 pre-existing failures unrelated to changes)
- ✅ Dev server: Running successfully on HTTP localhost:3000
- ✅ All endpoints working correctly

## Changes Made
- **Server**: Removed HTTPS createServer, simplified to app.listen()
- **Dependencies**: Removed "https" package from devDependencies
- **Tests**: Updated all HTTPS URLs to HTTP with centralized config
- **Documentation**: Updated feature notes to reflect HTTP setup
- **Files removed**: Entire .certs/ directory with certificates

HTTPS can be added back for production deployment if needed.

🤖 Generated with [Claude Code](https://claude.ai/code)